### PR TITLE
Adds freebsd support

### DIFF
--- a/.kitchen.freebsd.yml
+++ b/.kitchen.freebsd.yml
@@ -1,0 +1,47 @@
+---
+driver:
+  name: vagrant
+  hostname: freebsd.ci.local
+  cache_directory: false
+  customize:
+    memory: 2048
+  provision: true
+  linked_clone: true
+
+driver_config:
+  boot_timeout: 1200
+  provision_command:
+    - pkg install -y bash
+
+platforms:
+  - name: freebsd-11
+
+provisioner:
+  name: salt_solo
+  require_chef: false
+  salt_version: latest
+  formula: clamav
+  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'info' %>
+  salt_copy_filter:
+    - .kitchen
+    - .git
+  pillars-from-files:
+    clamav.sls: test/integration/pkg/pillar.example.freebsd
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - clamav
+  state_top:
+    base:
+      '*':
+        - clamav
+
+verifier:
+  name: inspec
+  use_sudo: yes
+  sudo_path: true
+  default_pattern: true
+
+suites:
+  - name: default

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,10 @@ gem "test-kitchen"
 gem "kitchen-docker"
 gem "kitchen-salt"
 gem "kitchen-inspec"
-gem "kitchen-vagrant" # for freebsd testing
 gem "net-ssh"
 gem "serverspec"
 gem "kitchen-verifier-serverspec"
+
+# for local freebsd testing
+# will fail if using travis
+gem "kitchen-vagrant", group: :freebsd

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "test-kitchen"
 gem "kitchen-docker"
 gem "kitchen-salt"
 gem "kitchen-inspec"
+gem "kitchen-vagrant" # for freebsd testing
 gem "net-ssh"
 gem "serverspec"
 gem "kitchen-verifier-serverspec"

--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,16 @@ for detecting Trojans, viruses, malware and other malicious threats
 
 On 'Redhat' based systems epel-formula should also be used
 
+To execute tests on 'FreeBSD' you need vagrant.
+  - Use `bundle install --with freebsd` before running kitchen.
+  - Execute `env KITCHEN_LOCAL_YAML=.kitchen.freebsd.yml kitchen test`
+
 .. note::
 
     See the full `Salt Formulas installation and usage instructions
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
-.. image:: https://travis-ci.org/aboe76/clamav-formula.svg?branch=master
+.. image:: https://travis-ci.org/saltstack-formulas/clamav-formula.svg?branch=master
 
 
 Available states

--- a/clamav/clamd/config.sls
+++ b/clamav/clamd/config.sls
@@ -13,8 +13,8 @@ clamd_config:
     - source: salt://clamav/files/clamd.conf
     - template: jinja
     - mode: 644
-    - user: root
-    - group: root
+    - user: {{ clamd.config_file_owner }}
+    - group: {{ clamd.config_file_group }}
     - require:
       - pkg: clamd_pkg
 

--- a/clamav/clamd/service.sls
+++ b/clamav/clamd/service.sls
@@ -7,12 +7,21 @@
 include:
   - .config
 
+{% if grains['os_family'] == 'FreeBSD' %}
+freshclam_initial:
+  cmd.run:
+    - name: /usr/local/bin/freshclam --quiet
+    - require:
+      - file: freshclam_config
+    - require_in: clamd_daemon
+{% endif %}
+
 clamd_daemon:
   service.{{ clamd.service_state }}:
     - name: {{ clamd.service_name }}
     - enable: {{ clamd.service_onboot }}
     - watch:
       - file: clamd_config
-    - require:  
+    - require:
       - file: clamd_config
       - pkg: clamd_pkg

--- a/clamav/defaults.yaml
+++ b/clamav/defaults.yaml
@@ -6,6 +6,8 @@ clamav:
     group: clamav
     config_path: /etc/clamav
     config_file: clamd.conf
+    config_file_owner: root
+    config_file_group: root
     service_name: clamav-daemon
     service_state: running
     service_onboot: True
@@ -26,13 +28,15 @@ clamav:
     group: clamav
     config_path: /etc/clamav
     config_file: freshclam.conf
+    config_file_owner: root
+    config_file_group: root
     service_name: clamav-freshclam
     service_state: running
     service_onboot: True
     config:
       UpdateLogFile: /var/log/clamav/freshclam.log
       LogFileMaxSize: 0
-      DatabaseMirror: 
+      DatabaseMirror:
         - db.local.clamav.net
         - database.clamav.net
       MaxAttempts: 5

--- a/clamav/freshclam/config.sls
+++ b/clamav/freshclam/config.sls
@@ -13,8 +13,8 @@ freshclam_config:
     - source: salt://clamav/files/freshclam.conf
     - template: jinja
     - mode: 644
-    - user: root
-    - group: root
+    - user: {{ freshclam.config_file_owner }}
+    - group: {{ freshclam.config_file_group }}
     - require:
       - pkg: freshclam_pkg
 

--- a/clamav/map.jinja
+++ b/clamav/map.jinja
@@ -92,6 +92,41 @@ that differ from whats in defaults.yaml
             },
           },
         },
+      'FreeBSD': {
+          'clamd': {
+            'pkgs': [ 'clamav' ],
+            'service_name': 'clamav-clamd',
+            'config_path': '/usr/local/etc',
+            'config_file': 'clamd.conf',
+            'config_file_group': 'wheel',
+            'config': {
+              'LogFile': '/var/log/clamav/clamd.log',
+              'PidFile': '/var/run/clamav/clamd.pid',
+              'DatabaseDirectory': '/var/db/clamav',
+              'DatabaseDirectory': '/var/tmp',
+              'FixStaleSocket': 'yes',
+              'LocalSocket': '/var/run/clamav/clamd.sock',
+              'User': 'clamav',
+              'ScanMail': 'yes',
+            },
+          },
+          'freshclam': {
+            'pkgs': [ 'clamav' ],
+            'service_name': 'clamav-freshclam',
+            'config_path': '/usr/local/etc',
+            'config_file': 'freshclam.conf',
+            'config_file_group': 'wheel',
+            'config': {
+              'NotifyClamd': '/usr/local/etc/clamd.conf',
+              'UpdateLogFile': '/var/log/clamav/freshclam.log',
+              'PidFile': '/var/run/clamav/freshclam.pid',
+              'DatabaseDirectory': '/var/db/clamav',
+              'DatabaseOwner': 'clamav',
+              'DatabaseMirror': 'database.clamav.net',
+            },
+          },
+        },
+
   }
   , grain="os_family"
   , merge=salt['pillar.get']('clamav:lookup'))

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,7 +27,6 @@ provisioner:
   salt_install: none
   require_chef: false
   formula: clamav
-  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'info' %>
   salt_copy_filter:
     - .kitchen
     - .git
@@ -92,28 +91,3 @@ suites:
             - clamav
         epel.sls:
           disabled: false
-
-  - name: pkg
-    excludes:
-      - debian-9
-      - ubuntu-16.04
-      - centos-7
-    provisioner:
-      salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py27-pip -p python -p bash
-    verifier:
-      name: inspec
-      default_pattern: true
-      env_vars:
-        SUDO: true
-    provisioner:
-      state_top:
-        base:
-          '*':
-            - clamav
-      pillars-from-files:
-        clamav.sls: test/integration/pkg/pillar.example.freebsd
-      pillars:
-        top.sls:
-          base:
-            '*':
-            - clamav

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,6 +27,7 @@ provisioner:
   salt_install: none
   require_chef: false
   formula: clamav
+  log_level: <%= ENV['SALT_DEBUG_LEVEL'] || 'info' %>
   salt_copy_filter:
     - .kitchen
     - .git
@@ -91,3 +92,28 @@ suites:
             - clamav
         epel.sls:
           disabled: false
+
+  - name: pkg
+    excludes:
+      - debian-9
+      - ubuntu-16.04
+      - centos-7
+    provisioner:
+      salt_bootstrap_options: -p git -p curl -p ca_root_nss -p py27-pip -p python -p bash
+    verifier:
+      name: inspec
+      default_pattern: true
+      env_vars:
+        SUDO: true
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - clamav
+      pillars-from-files:
+        clamav.sls: test/integration/pkg/pillar.example.freebsd
+      pillars:
+        top.sls:
+          base:
+            '*':
+            - clamav

--- a/test/integration/pkg/inspec/clamav_spec.rb
+++ b/test/integration/pkg/inspec/clamav_spec.rb
@@ -1,0 +1,15 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe package('clamav') do
+  it { should be_installed }
+end
+
+describe service('clamav-freshclam') do
+  it { should be_enabled }
+end
+
+describe service('clamav-clamd') do
+  it { should be_enabled }
+end

--- a/test/integration/pkg/pillar.example.freebsd
+++ b/test/integration/pkg/pillar.example.freebsd
@@ -1,0 +1,91 @@
+clamav:
+  clamd:
+    config:
+      LogFile: /var/log/clamav/clamav.log
+      LogTime: 'yes'
+      LogFileMaxSize: 2M
+      LogFileUnlock: 'no'
+      LocalSocket: /var/run/clamav/clamd.sock
+      LocalSocketGroup: clamav
+      LocalSocketMode: 666
+      FixStaleSocket: 'yes'
+      User: clamav
+      SelfCheck: 3600
+      ScanMail: 'yes'
+      ScanArchive: 'yes'
+      ArchiveBlockEncrypted: 'no'
+      MaxDirectoryRecursion: 15
+      FollowDirectorySymlinks: 'no'
+      FollowFileSymlinks: 'no'
+      ReadTimeout: 180
+      MaxThreads: 12
+      MaxConnectionQueueLength: 15
+      LogSyslog: 'no'
+      LogRotate: 'yes'
+      LogFacility: LOG_MAIL
+      LogClean: 'no'
+      LogVerbose: 'no'
+      DatabaseDirectory: /var/db/clamav
+      OfficialDatabaseOnly: 'no'
+      Foreground: 'no'
+      Debug: 'no'
+      MaxEmbeddedPE: 10M
+      MaxHTMLNormalize: 10M
+      MaxHTMLNoTags: 2M
+      MaxScriptNormalize: 5M
+      MaxZipTypeRcg: 1M
+      ExitOnOOM: 'no'
+      LeaveTemporaryFiles: 'no'
+      IdleTimeout: 30
+      CrossFilesystems: 'yes'
+      ScanPartialMessages: 'no'
+      CommandReadTimeout: 5
+      SendBufTimeout: 200
+      MaxQueue: 100
+      ExtendedDetectionInfo: 'yes'
+      OLE2BlockMacros: 'no'
+      ScanOnAccess: 'no'
+      ForceToDisk: 'no'
+      DisableCertCheck: 'no'
+      DisableCache: 'no'
+      MaxScanSize: 100M
+      MaxFileSize: 25M
+      MaxRecursion: 16
+      MaxFiles: 10000
+      MaxPartitions: 50
+      MaxIconsPE: 100
+      PCREMatchLimit: 10000
+      PCRERecMatchLimit: 5000
+      PCREMaxFileSize: 25M
+      StreamMaxLength: 25M
+      Bytecode: 'yes'
+      BytecodeSecurity: TrustSigned
+      BytecodeTimeout: 60000
+
+  freshclam:
+    config:
+      DatabaseOwner: clamav
+      UpdateLogFile: /var/log/clamav/freshclam.log
+      LogVerbose: 'no'
+      LogSyslog: 'no'
+      LogFacility: LOG_MAIL
+      LogFileMaxSize: 0
+      LogRotate: 'yes'
+      LogTime: 'yes'
+      Foreground: 'no'
+      Debug: 'no'
+      MaxAttempts: 5
+      DatabaseDirectory: /var/db/clamav
+      DNSDatabaseInfo: current.cvd.clamav.net
+      ConnectTimeout: 30
+      ReceiveTimeout: 30
+      TestDatabases: 'yes'
+      ScriptedUpdates: 'yes'
+      CompressLocalDatabase: 'no'
+      SafeBrowsing: 'no'
+      Bytecode: 'yes'
+      Checks: 24
+      DatabaseMirror:
+        - db.local.clamav.net
+        - database.clamav.net
+


### PR DESCRIPTION
This PR adds support for FreeBSD. Changes are:

- tests need to be run using `vagrant`, so kitchen vagrant has been added
- updated map with correcponding paths and names
- `clamav-clamd` service in FreeBSD won't boot until freshclam has downloaded the initial files, so added that
- added two new variables: config files belong to wheel group